### PR TITLE
[TSK-640] Load images in case study on demand

### DIFF
--- a/src/app/_components/view-case-study.tsx
+++ b/src/app/_components/view-case-study.tsx
@@ -1,11 +1,33 @@
 "use client";
 
-import {useEffect, useRef, useState} from "react";
+import { useEffect, useRef, useState } from "react";
 import { CaseStudyPage, StepProgress } from "@maany_shr/rage-ui-kit";
 import type { TCaseStudyViewModel } from "~/lib/core/view-models/case-study-view-model";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { caseStudyMutation, DEFAULT_RETRIES, DEFAULT_RETRY_DELAY } from "~/app/queries";
 import { ChatClientPage } from "~/app/_components/chat-page";
+import clientContainer from "~/lib/infrastructure/client/config/ioc/client-container";
+import { GATEWAYS } from "~/lib/infrastructure/client/config/ioc/client-ioc-symbols";
+import BrowserKernelSourceDataGateway from "~/lib/infrastructure/client/gateway/browser-source-data-gateway";
+
+const fetchSignedImageUrl = async (imagePath: string): Promise<string> => {
+  const sourceDataGateway = clientContainer.get<BrowserKernelSourceDataGateway>(GATEWAYS.KERNEL_SOURCE_DATA_GATEWAY);
+  const response = await sourceDataGateway.getClientDataForDownload(imagePath);
+
+  if (!response.success) throw Error(`Failed to get signed URL: ${response.data.message}`);
+
+  return response.data;
+};
+
+export const useSignedImageUrl = (imagePath: string) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["signedUrl", imagePath],
+    queryFn: () => fetchSignedImageUrl(imagePath),
+    staleTime: 60 * 60 * 1000, // 1 hour cache
+  });
+
+  return { data, isLoading, error };
+};
 
 type ViewCaseStudyProps = {
   caseStudy: string;
@@ -48,7 +70,7 @@ export const ViewCaseStudy = (props: ViewCaseStudyProps) => {
     if (caseStudyViewModel.status === "progress") {
       setStep((prev) => prev + 1);
     } else {
-      setStep(0)
+      setStep(0);
     }
   }, [caseStudyViewModel]);
 
@@ -86,6 +108,7 @@ export const ViewCaseStudy = (props: ViewCaseStudyProps) => {
 
   return (
     <CaseStudyPage
+      useSignedImageUrl={useSignedImageUrl}
       info={caseStudyViewModel.metadata}
       sideComponent={
         <ChatClientPage

--- a/src/lib/core/entity/case-study-models.ts
+++ b/src/lib/core/entity/case-study-models.ts
@@ -13,7 +13,6 @@ export type TError = z.infer<typeof ErrorSchema>;
 export const ImageSchema = z.object({
   relativePath: z.string(),
   description: z.string(),
-  signedUrl: z.string().url(),
   kind: z.string(),
 });
 export type TImage = z.infer<typeof ImageSchema>;

--- a/src/lib/infrastructure/server/utils/sda-case-study-utils.ts
+++ b/src/lib/infrastructure/server/utils/sda-case-study-utils.ts
@@ -1,13 +1,8 @@
 import { z } from "zod";
 import {
-  ClimateKeyframeSchema,
   ClimateMetadataSchema,
-  ClimateRowSchema, ErrorSchema,
-  ImageSchema,
-  SentinelKeyframeSchema,
   SentinelMetadataSchema,
-  SentinelRowSchema, SwissGridKeyframeSchema, SwissGridMetadataSchema,
-  SwissGridRowSchema
+  SwissGridMetadataSchema,
 } from "~/lib/core/entity/case-study-models";
 
 /**
@@ -18,60 +13,34 @@ export const generateMetadataRelativePath = (caseStudyName: string, tracerID: st
   return `${caseStudyName}/${tracerID}/${jobID}/metadata.json`;
 };
 
-export const RawImageSchema = ImageSchema.omit({
-  signedUrl: true,
-});
 
 /**
  * climate-monitoring
  */
 
-const RawClimateKeyframeSchema = ClimateKeyframeSchema.omit({ images: true }).extend({
-  images: z.array(RawImageSchema.or(ErrorSchema)),
-});
 const RawClimateMetadataSchema = ClimateMetadataSchema.omit({
-  keyframes: true,
   expirationTime: true,
-}).extend({
-  keyframes: z.array(RawClimateKeyframeSchema),
 });
 
 /**
  * sentinel-5P
  */
 
-const RawSentinelKeyframeSchema = SentinelKeyframeSchema.omit({ images: true }).extend({
-  images: z.array(RawImageSchema.or(ErrorSchema)),
-});
-
 const RawSentinelMetadataSchema = SentinelMetadataSchema.omit({
-  keyframes: true,
   expirationTime: true,
-}).extend({
-  keyframes: z.array(RawSentinelKeyframeSchema),
 });
 
 /**
  * swissgrid
  */
 
-const RawSwissGridKeyframeSchema = SwissGridKeyframeSchema.omit({ images: true }).extend({
-  images: z.array(RawImageSchema.or(ErrorSchema)),
-});
-
 const RawSwissGridMetadataSchema = SwissGridMetadataSchema.omit({
-  keyframes: true,
   expirationTime: true,
-}).extend({
-  keyframes: z.array(RawSwissGridKeyframeSchema),
 });
 
 /**
  * types
  */
-
-export const RawKeyframeSchema = z.union([RawClimateKeyframeSchema, RawSentinelKeyframeSchema, RawSwissGridKeyframeSchema]);
-export type TRawKeyframe = z.infer<typeof RawKeyframeSchema>;
 
 export const RawCaseStudyMetadataSchema = z.discriminatedUnion("caseStudy", [RawClimateMetadataSchema, RawSentinelMetadataSchema, RawSwissGridMetadataSchema]);
 export type TRawCaseStudyMetadata = z.infer<typeof RawCaseStudyMetadataSchema>;

--- a/tests/server/kernel/sda-case-study-repository.test.ts
+++ b/tests/server/kernel/sda-case-study-repository.test.ts
@@ -223,12 +223,6 @@ describe('SDACaseStudyRepository', () => {
                 },
             });
 
-            // Mock signed URL responses for images
-            mockKernelSourceDataGateway.getClientDataForDownload.mockResolvedValue({
-                success: true,
-                data: 'https://example.com/signed-url',
-            });
-
             // Mock file system
             // @ts-ignore (mocking fs.readFileSync)
             fs.readFileSync.mockReturnValue(Buffer.from(JSON.stringify(mockClimateMonitoringMetadata)));
@@ -241,7 +235,6 @@ describe('SDACaseStudyRepository', () => {
             expect(result.data.caseStudy).toBe('climate-monitoring');
             expect(result.data.keyframes).toHaveLength(1);
             expect(result.data.keyframes[0].images).toHaveLength(1);
-            expect(result.data.keyframes[0].images[0].signedUrl).toBe('https://example.com/signed-url');
 
             // Verify that expiration time was added and is roughly an hour in the future
             expect(result.data.expirationTime).toBeDefined();
@@ -347,38 +340,6 @@ describe('SDACaseStudyRepository', () => {
             expect(result.data.message).toBe('Failed to parse metadata.');
         });
 
-        it('should handle image fetch failure', async () => {
-            // Mock download success
-            mockKernelSourceDataGateway.download.mockResolvedValue({
-                success: true,
-                data: {
-                    relativePath: '/tmp/local-path/metadata.json',
-                },
-            });
-
-            // Mock signed URL failure
-            mockKernelSourceDataGateway.getClientDataForDownload.mockResolvedValue({
-                success: false,
-                data: {
-                    message: 'Failed to generate signed URL',
-                },
-            });
-
-            // @ts-ignore (mocking fs.readFileSync)
-            fs.readFileSync.mockReturnValue(Buffer.from(JSON.stringify(mockClimateMonitoringMetadata)));
-
-            // Execute method
-            const result = await repository.getCaseStudyMetadata('climate-monitoring', 'tracer-123', 456);
-
-            // Assertions
-            expect(result.success).toBe(true);
-            expect(result.data.keyframes[0].images[0]).toEqual({
-                errorMessage: 'Failed to fetch image.',
-                errorName: 'ImageFetchError',
-            });
-            expect(mockLogger.error).toHaveBeenCalled();
-        });
-
         it('should handle unexpected exceptions', async () => {
             // Mock download to throw exception
             mockKernelSourceDataGateway.download.mockRejectedValue(new Error('Unexpected error'));
@@ -398,12 +359,6 @@ describe('SDACaseStudyRepository', () => {
                 data: {
                     relativePath: '/tmp/local-path/metadata.json',
                 },
-            });
-
-            // Mock signed URL responses for images
-            mockKernelSourceDataGateway.getClientDataForDownload.mockResolvedValue({
-                success: true,
-                data: 'https://example.com/signed-url',
             });
 
             // Mock file system
@@ -426,12 +381,6 @@ describe('SDACaseStudyRepository', () => {
                 data: {
                     relativePath: '/tmp/local-path/metadata.json',
                 },
-            });
-
-            // Mock signed URL responses for images
-            mockKernelSourceDataGateway.getClientDataForDownload.mockResolvedValue({
-                success: true,
-                data: 'https://example.com/signed-url',
             });
 
             // Mock file system


### PR DESCRIPTION
The server-side feature to process metadata now doesn't request signed URLs as it takes a lot of time and might cause timeout in some environments. Instead an on-demand approach is utilized with caching the images for 1 hour (the expected expiry time).

Passing the CI requires updating the UI kit with https://github.com/dream-aim-deliver/rage-ui-kit/pull/102